### PR TITLE
Feature/endpoint resume conv

### DIFF
--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -923,15 +923,15 @@ def create_app(agent=None,
         return response.json(responses)
 
 def retrieve_keys(app):
-        """ Retrieves the list of keys of the tracker store
+    """ Retrieves the list of keys of the tracker store
 
-        Returns:
-            list -- tracker_store list of keys
-        """
-        keys = []
-        if app.agent.tracker_store:
-            keys = list(app.agent.tracker_store.keys())
-        return keys
+    Returns:
+        list -- tracker_store list of keys
+    """
+    keys = []
+    if app.agent.tracker_store:
+        keys = list(app.agent.tracker_store.keys())
+    return keys
 
 def compare_utcdatetime_with_gap(dt_a, dt_b, gap):
     """Check the gap between two datetimes

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 import zipfile
+import datetime
 from functools import wraps, reduce
 from inspect import isawaitable
 from typing import Any, Callable, List, Optional, Text, Union
@@ -353,7 +354,7 @@ def create_app(agent=None,
             keys = []
 
         return response.json(keys)
-
+    
     @app.get("/conversations/<sender_id>/tracker")
     @requires_auth(app, auth_token)
     async def retrieve_tracker(request: Request, sender_id: Text):
@@ -868,6 +869,82 @@ def create_app(agent=None,
 
     return app
 
+    @app.route("/conversations/trigger_action_to_ids_24h", methods=['POST'])
+    @requires_auth(app, auth_token)
+    @ensure_loaded_agent(app)
+    async def trigger_action_if_lastevent_24h(request: Request):
+        """ Get the last event timestamp from a list of ids
+        and trigger an action if the last event was made more than a day ago
+
+        Returns
+            responses: A jsonify dict of sender_ids on which the action trigger were call to
+        """
+        # retrieve parameters
+        request_params = request.json
+        action_to_execute = (request_params.get("name") or
+                             request_params.get("action"))
+        policy = request_params.get("policy", None)
+        confidence = request_params.get("confidence", None)
+        verbosity = event_verbosity_parameter(request,
+                                              EventVerbosity.AFTER_RESTART)
+        # dict of responses
+        responses = {}
+        # Retrieve ids from tracker_store
+        ids = retrieve_keys(app)
+        # For each ids, trigger an action if it was stalled for more than a day 
+        for id in ids:
+            tracker = app.agent.tracker_store.get_or_create_tracker(id)
+            id_state = tracker.current_state(verbosity)
+            current_time = datetime.datetime.utcnow()
+            last_event_ts_from_id = datetime.datetime.utcfromtimestamp(id_state["latest_event_time"])
+            secondsinaday = 8
+            if compare_utcdatetime_with_gap(current_time, last_event_ts_from_id, secondsinaday):
+                try:
+                    output_channel = _get_output_channel(request, tracker)
+                    logger.info('output_channel: {}'.format(output_channel))
+                    await app.agent.execute_action(id,
+                                                action_to_execute,
+                                                output_channel,
+                                                policy,
+                                                confidence)
+
+                    responses[id] = "Action trigger sent"
+
+                except ValueError as e:
+                    raise ErrorResponse(400, "ValueError", e)
+                except Exception as e:
+                    logger.error("Encountered an exception while running action '{}'. "
+                                "Bot will continue, but the actions events are lost. "
+                                "Make sure to fix the exception in your custom "
+                                "code.".format(action_to_execute))
+                    logger.debug(e, exc_info=True)
+                    raise ErrorResponse(500, "ValueError",
+                                        "Server failure. Error: {}".format(e))
+        return response.json(responses)
+
+def retrieve_keys(app):
+        """ Retrieves the list of keys of the tracker store
+
+        Returns:
+            list -- tracker_store list of keys
+        """
+        keys = []
+        if app.agent.tracker_store:
+            keys = list(app.agent.tracker_store.keys())
+        return keys
+
+def compare_utcdatetime_with_gap(dt_a, dt_b, gap):
+    """Check the gap between two datetimes
+
+    Arguments:
+        dt_a {UTCdatetime} -- Time A to compared
+        dt_b {UTCdatetime} -- Time B to compared
+        gap {int} -- gap to considered in seconds
+
+    Returns:
+        Bool -- True if dt_a is more recent than dt_b + gap
+    """
+    return ((dt_a - dt_b).total_seconds() >= gap)
 
 def set_key_value(key):
     if key == "event":

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -897,7 +897,7 @@ def create_app(agent=None,
             id_state = tracker.current_state(verbosity)
             current_time = datetime.datetime.utcnow()
             last_event_ts_from_id = datetime.datetime.utcfromtimestamp(id_state["latest_event_time"])
-            secondsinaday = 8
+            secondsinaday = 86400
             if compare_utcdatetime_with_gap(current_time, last_event_ts_from_id, secondsinaday):
                 try:
                     output_channel = _get_output_channel(request, tracker)

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -887,7 +887,7 @@ def create_app(agent=None,
         confidence = request_params.get("confidence", None)
         verbosity = event_verbosity_parameter(request,
                                               EventVerbosity.AFTER_RESTART)
-        # dict of responses
+        # dict of responses that will store all the ids that were updated as keys
         responses = {}
         # Retrieve ids from tracker_store
         ids = retrieve_keys(app)
@@ -895,6 +895,7 @@ def create_app(agent=None,
         for id in ids:
             tracker = app.agent.tracker_store.get_or_create_tracker(id)
             id_state = tracker.current_state(verbosity)
+            # check if the last event was made within the last 86400secs (24h)
             current_time = datetime.datetime.utcnow()
             last_event_ts_from_id = datetime.datetime.utcfromtimestamp(id_state["latest_event_time"])
             secondsinaday = 86400
@@ -907,7 +908,7 @@ def create_app(agent=None,
                                                 output_channel,
                                                 policy,
                                                 confidence)
-
+                    # add id to result
                     responses[id] = "Action trigger sent"
 
                 except ValueError as e:

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -874,7 +874,7 @@ def create_app(agent=None,
     @ensure_loaded_agent(app)
     async def trigger_action_if_lastevent_24h(request: Request):
         """ Get the last event timestamp from a list of ids
-        and trigger an action if the last event was made more than a day ago
+        and trigger an action if their last event was made more than a day ago
 
         Returns
             responses: A jsonify dict of sender_ids on which the action trigger were call to


### PR DESCRIPTION
**Proposed changes**:
-  Adding the new api endpoint to trigger an action to users who have their last event made more than a day ago.

**What it does**:
- Retrieve ids
- From the ids, compare their last event timestamp with the current timestamp.
- If their last event was not made within the last 24h, execute an action

**What it needs**:
- It's a post request endpoint that needs a body with the name of the action and a confidence value
```json
{
   "name": <enter_action_name>,
   "confidence": <enter_amount_of_confidence>
}
```
**What you can enter as parameters**:
- It can have a parameter related to the output_channel:
```json
{
    "output_channel" :"twilio"
}
```
    
**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
